### PR TITLE
🐛(midi_player): fix midi message 

### DIFF
--- a/src/midi/midi_player.rs
+++ b/src/midi/midi_player.rs
@@ -65,7 +65,7 @@ impl MidiPlayer {
     pub fn play_notes(&mut self, ch: u8, notes: &[u8]) {
         if let Some(conn) = &mut self.midi_out_conn {
             for (index, note) in notes.iter().enumerate() {
-                let _ = conn.send(&[0x90 | (ch & 0xF) | (index as u8 & 0x0F), *note, 0x64]);
+                let _ = conn.send(&[0x90 | (ch & 0xF), *note, 0x64]);
             }
         }
     }
@@ -73,7 +73,7 @@ impl MidiPlayer {
     pub fn stop_notes(&mut self, ch: u8, notes: &[u8]) {
         if let Some(conn) = &mut self.midi_out_conn {
             for (index, note) in notes.iter().enumerate() {
-                let _ = conn.send(&[0x80 | (ch & 0xF) | (index as u8 & 0x0F), *note, 0x64]);
+                let _ = conn.send(&[0x80 | (ch & 0xF), *note, 0x64]);
             }
         }
     }


### PR DESCRIPTION
fix stupid midi message wrong channel.